### PR TITLE
fix: remove `ci` env from cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,6 @@ concurrency:
 jobs:
   cypress:
     name: Cypress
-    environment: ci
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
Remove env as it is miss-leading and confusing.