### PR TITLE
fix: allow no recaptcha key in dev

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,32 +4,32 @@
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
     "prettier",
-    "react-app"
+    "react-app",
   ],
   "env": {
     "browser": true,
     "node": true,
     "mocha": true,
-    "jest": true
+    "jest": true,
   },
   "globals": {
     "cy": true,
-    "Cypress": true
+    "Cypress": true,
   },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {
-      "jsx": true
+      "jsx": true,
     },
-    "requireConfigFile": false
+    "requireConfigFile": false,
   },
   "rules": {
-    "react/require-default-props": "off" ,
+    "react/require-default-props": "off",
     "react/jsx-filename-extension": [
       1,
       {
-        "extensions": [".js", ".jsx", ".ts", ".tsx"]
-      }
+        "extensions": [".js", ".jsx", ".ts", ".tsx"],
+      },
     ],
     "react/static-property-placement": [
       "error",
@@ -40,15 +40,17 @@
         "contextType": "static public field",
         "defaultProps": "static public field",
         "displayName": "static public field",
-        "propTypes": "static public field"
-      }
+        "propTypes": "static public field",
+      },
     ],
     "react/state-in-constructor": ["error", "never"],
-    "no-console": [1, { "allow": ["error"] }],
+    "no-console": [1, { "allow": ["error", "debug"] }],
     "no-restricted-syntax": "off",
     "react/jsx-uses-vars": "error",
-    "react/function-component-definition":  
-      [2, { "namedComponents": "arrow-function" }]
+    "react/function-component-definition": [
+      2,
+      { "namedComponents": "arrow-function" },
+    ],
   },
-  "ignorePatterns": ["node_modules/*", "public"]
+  "ignorePatterns": ["node_modules/*", "public"],
 }


### PR DESCRIPTION
In this PR:
- allow to not net a recaptcha key in dev: we will send a mock value to the backend who does not check it.

Question: 
I did not add a test for this. 
The expected behaviour is that if you do not have the `VITE_RECAPTCHA_SITE_KEY` env variable it should send the mock token in the login and register payloads.
If you have the `VITE_RECAPTCHA_SITE_KEY` variable but it has a value of `""`, then it will also send a mock value.
If you have a correct key it will use that correct key. 