### PR TITLE
fix: password icon use lock icon

### DIFF
--- a/src/components/common/Adornments.tsx
+++ b/src/components/common/Adornments.tsx
@@ -1,4 +1,4 @@
-import { MailIcon, RectangleEllipsisIcon } from 'lucide-react';
+import { LockIcon, MailIcon } from 'lucide-react';
 
 import { InputAdornment } from '@mui/material';
 
@@ -9,6 +9,6 @@ export const EmailAdornment = (
 );
 export const PasswordAdornment = (
   <InputAdornment position="start" sx={{ color: 'inherit' }}>
-    <RectangleEllipsisIcon color="currentColor" />
+    <LockIcon color="currentColor" />
   </InputAdornment>
 );

--- a/src/components/common/Adornments.tsx
+++ b/src/components/common/Adornments.tsx
@@ -3,12 +3,12 @@ import { LockIcon, MailIcon } from 'lucide-react';
 import { InputAdornment } from '@mui/material';
 
 export const EmailAdornment = (
-  <InputAdornment position="start" sx={{ color: 'inherit' }}>
+  <InputAdornment position="start" color="inherit">
     <MailIcon color="currentColor" />
   </InputAdornment>
 );
 export const PasswordAdornment = (
-  <InputAdornment position="start" sx={{ color: 'inherit' }}>
+  <InputAdornment position="start" color="inherit">
     <LockIcon color="currentColor" />
   </InputAdornment>
 );

--- a/src/components/common/PasswordInput.tsx
+++ b/src/components/common/PasswordInput.tsx
@@ -25,25 +25,26 @@ export function PasswordInput({ id, error, form }: Props): JSX.Element {
 
   return (
     <StyledTextField
-      InputProps={{
-        startAdornment: PasswordAdornment,
-        endAdornment: (
-          <InputAdornment position="end" color="inherit">
-            <IconButton
-              aria-label="toggle password visibility"
-              onClick={handleClickShowPassword}
-              //   onMouseDown={handleMouseDownPassword}
-              edge="end"
-              color="inherit"
-            >
-              {showPassword ? (
-                <EyeOffIcon color="currentColor" />
-              ) : (
-                <EyeIcon color="currentColor" />
-              )}
-            </IconButton>
-          </InputAdornment>
-        ),
+      slotProps={{
+        input: {
+          startAdornment: PasswordAdornment,
+          endAdornment: (
+            <InputAdornment position="end" color="inherit">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={handleClickShowPassword}
+                edge="end"
+                color="inherit"
+              >
+                {showPassword ? (
+                  <EyeOffIcon color="currentColor" />
+                ) : (
+                  <EyeIcon color="currentColor" />
+                )}
+              </IconButton>
+            </InputAdornment>
+          ),
+        },
       }}
       variant="outlined"
       error={Boolean(error)}

--- a/src/components/requestPasswordReset/ResetPassword.tsx
+++ b/src/components/requestPasswordReset/ResetPassword.tsx
@@ -32,6 +32,7 @@ import {
 import { useValidateJWTToken } from '../../hooks/useValidateJWTToken';
 import { AUTH } from '../../langs/constants';
 import { getValidationMessage } from '../../utils/validation';
+import { PasswordAdornment } from '../common/Adornments';
 import { CenteredContent } from '../layout/CenteredContent';
 import { DialogHeader } from '../layout/DialogHeader';
 import { InvalidTokenScreen } from './InvalidTokenScreen';
@@ -124,14 +125,19 @@ export function ResetPassword() {
       >
         <TextField
           id={RESET_PASSWORD_NEW_PASSWORD_FIELD_ID}
+          slotProps={{
+            input: {
+              startAdornment: PasswordAdornment,
+            },
+            formHelperText: {
+              id: RESET_PASSWORD_NEW_PASSWORD_FIELD_ERROR_TEXT_ID,
+            },
+          }}
           {...register('password', {
             required: true,
             validate: (value) =>
               isPasswordStrong(value) || AUTH.PASSWORD_WEAK_ERROR,
           })}
-          FormHelperTextProps={{
-            id: RESET_PASSWORD_NEW_PASSWORD_FIELD_ERROR_TEXT_ID,
-          }}
           label={t(AUTH.RESET_PASSWORD_NEW_PASSWORD_FIELD_LABEL)}
           variant="outlined"
           error={Boolean(passwordErrorMessage)}
@@ -142,6 +148,14 @@ export function ResetPassword() {
         />
         <TextField
           id={RESET_PASSWORD_NEW_PASSWORD_CONFIRMATION_FIELD_ID}
+          slotProps={{
+            input: {
+              startAdornment: PasswordAdornment,
+            },
+            formHelperText: {
+              id: RESET_PASSWORD_NEW_PASSWORD_CONFIRMATION_FIELD_ERROR_TEXT_ID,
+            },
+          }}
           {...register('confirmPassword', {
             required: true,
             validate: {
@@ -152,9 +166,6 @@ export function ResetPassword() {
                 AUTH.PASSWORD_DO_NOT_MATCH_ERROR,
             },
           })}
-          FormHelperTextProps={{
-            id: RESET_PASSWORD_NEW_PASSWORD_CONFIRMATION_FIELD_ERROR_TEXT_ID,
-          }}
           label={t(AUTH.RESET_PASSWORD_NEW_PASSWORD_CONFIRMATION_FIELD_LABEL)}
           variant="outlined"
           error={Boolean(confirmPasswordErrorMessage)}


### PR DESCRIPTION
Use a lock icon instead of the previous choice or rectangle with ellipsis.

<img width="413" alt="Screenshot 2024-10-30 at 14 11 31" src="https://github.com/user-attachments/assets/dfbc6cff-3479-4d70-ae69-12cb81e8dc1d">
